### PR TITLE
Fix for some flow-router scenarios

### DIFF
--- a/london:body-class.js
+++ b/london:body-class.js
@@ -34,13 +34,15 @@ results in `<body class="alpha">`
 
 by: @olizilla for meteor-london
 */
+var prevSingleton
 
 Blaze.addBodyClass = function (fn) {
   if($.isArray(fn)) {
     return fn.forEach(Blaze.addBodyClass)
   }
   if(typeof fn !== 'function') {
-    return Meteor.startup(function () { $('body').addClass(fn) })
+    $('body').removeClass(prevSingleton)
+    return Meteor.startup(function () { $('body').addClass(prevSingleton = fn) })
   }
 
   Meteor.startup(function () {
@@ -60,12 +62,9 @@ if(Package['iron:router']) {
 }
 if(Package['meteorhacks:flow-router'] || Package['kadira:flow-router']) {
   Meteor.startup(function () {
-    Blaze.addBodyClass(function () {
-      FlowRouter.watchPathChange();
-      var currentContext = FlowRouter.current();
-      return currentContext &&
-             currentContext.route &&
-             currentContext.route.name
-    });
+    Blaze.addBodyClass(FlowRouter.getRouteName())
+    FlowRouter.triggers.enter([function (context) {
+      Blaze.addBodyClass(context.route.name)
+    }])
   })
 }

--- a/london:body-class.js
+++ b/london:body-class.js
@@ -62,6 +62,7 @@ if(Package['iron:router']) {
 }
 if(Package['meteorhacks:flow-router'] || Package['kadira:flow-router']) {
   Meteor.startup(function () {
+    // Since we need to wait for startup, we need to addBodyClass immediately, as the entry page will already have rendered
     Blaze.addBodyClass(FlowRouter.getRouteName())
     FlowRouter.triggers.enter([function (context) {
       Blaze.addBodyClass(context.route.name)

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Giving you `Blaze.addBodyClass` for reactive class names on the body element',
-  version: '2.2.0',
+  version: '2.3.0',
   name: 'london:body-class',
   git: 'https://github.com/meteor-london/body-class.git'
 })
@@ -11,5 +11,6 @@ Package.onUse(function (api) {
   api.use('jquery', 'client')
   api.use('iron:router@1.0.0','client', { 'weak': true })
   api.use('meteorhacks:flow-router@1.4.0', 'client', { 'weak': true })
+  api.use('kadira:flow-router@2.0.0', 'client', { 'weak': true })
   api.addFiles('london:body-class.js', 'client')
 })


### PR DESCRIPTION
Sometimes, body-class was returning the previous route as a class name.  This is due to a [page.js issue](https://github.com/visionmedia/page.js/issues/295) in which callbacks are fired before the route actually changes.  To fix this, we need to use the context object to get the current route, rather than watching path changes and using `FlowRouter.getRouteName()` as the latter may not be updated.  In order to use the context, we need to pass the callback as a FlowRouter trigger rather than an autorun.
